### PR TITLE
Fix driver name column parsing from google sheet

### DIFF
--- a/google_integration.py
+++ b/google_integration.py
@@ -290,8 +290,12 @@ class GoogleSheetsIntegration:
 
     @staticmethod
     def _norm_driver(s):
-        """Normalize driver name"""
-        return str(s or "").strip().lower()
+        """Normalize driver name so that variations like 'John Doe / Jane' are handled consistently"""
+        if s is None:
+            return ""
+        # Take text before any '/' or ',' delimiters, common in dual-driver entries
+        name = str(s).split("/")[0].split(",")[0]
+        return name.strip().lower()
 
     def _get_groups_records_safe(self):
         """


### PR DESCRIPTION
Normalize driver names to ensure consistent parsing from Google Sheets and resolve "Driver Name" column not found errors.

This change updates the `_norm_driver()` helper to handle `None` values and remove text after common delimiters like '/' or ',' (e.g., "John Doe / Jane"). This ensures that driver keys derived from QC Panel rows consistently match those from the Assets sheet, preventing "column not found" errors and allowing active loads to be correctly synced.

---
<a href="https://cursor.com/background-agent?bcId=bc-d731589b-0b9d-40fd-80e9-54c115f7db3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d731589b-0b9d-40fd-80e9-54c115f7db3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

